### PR TITLE
chore: Ignore SlideWiki links

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -14,6 +14,12 @@
     },
     {
       "pattern": "https://gcconnex.gc.ca"
+    },
+    {
+      "pattern": "http(s)?://slidewiki.aksw.org"
+    },
+    {
+      "pattern": "https://slidewiki.org"
     }
   ]
 }


### PR DESCRIPTION
- the aksw version has been 503 for some time
- the regular slidewiki.org is very slow loading

Temporary related to #56